### PR TITLE
Store CONTAINER_ID output from docker run

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-docker run -u zap -p 8080:8080 -d owasp/zap2docker-stable zap.sh -daemon -port 8080 -host 0.0.0.0 -config api.disablekey=true
+CONTAINER_ID=$(docker run -u zap -p 8080:8080 -d owasp/zap2docker-stable zap.sh -daemon -port 8080 -host 0.0.0.0 -config api.disablekey=true)
 
 # XXX - FIXME: should smartly listen for ZAP-readiness, rather than hard-code a sleep
 sleep 10
 
-docker exec $(docker ps -lq) zap-cli open-url https://www.allizom.org/en-US/firefox/
+docker exec $CONTAINER_ID zap-cli open-url https://www.allizom.org/en-US/firefox/
 
 # XXX - FIXME: not only should the hard-coded host be removed, but we should pass in more-aggressive active-scan options, here
-docker exec $(docker ps -lq) zap-cli active-scan https://www.allizom.org/en-US/firefox/
+docker exec $CONTAINER_ID zap-cli active-scan https://www.allizom.org/en-US/firefox/
 
 # docker logs [container ID or name]
-docker logs $(docker ps -lq)
+docker logs $CONTAINER_ID
 
-docker stop $(docker ps -lq)
+docker stop $CONTAINER_ID


### PR DESCRIPTION
Use $CONTAINER_ID in subsequent commands

Replace brittle calls to $(docker ps -lq) which will not break if other docker containers are already running when script is executed.
