### PR TITLE
Remove hardcoded sleep and poll/wait for ZAP-API readiness - fixes ht…

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -5,10 +5,7 @@ CONTAINER_ID=$(docker run -u zap -p 2375:2375 -d owasp/zap2docker-weekly zap.sh 
 # the target URL for ZAP to scan
 TARGET_URL=""
 
-# XXX - FIXME: should smartly listen for ZAP-readiness, rather than hard-code a sleep
-sleep 20
-
-docker exec $CONTAINER_ID zap-cli -p 2375 open-url $TARGET_URL
+docker exec $CONTAINER_ID zap-cli -p 2375 status -t 60 && docker exec $CONTAINER_ID zap-cli -p 2375 open-url $TARGET_URL
 
 docker exec $CONTAINER_ID zap-cli -p 2375 spider $TARGET_URL
 


### PR DESCRIPTION
…tps://github.com/stephendonner/docker-zap/issues/1

Now we poll ZAP-API readiness, up to 60 seconds, before we open-url.  And return "ZAP is not running", if it's not ready (although we continue on, later).
